### PR TITLE
OAK-8466: Old inactive clusterIds may trigger expensive recovery

### DIFF
--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/Commit.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/Commit.java
@@ -789,6 +789,18 @@ public class Commit {
         cacheEntry.done();
     }
 
+    void markChanged(Path path) {
+        while (true) {
+            if (!modifiedNodes.add(path)) {
+                break;
+            }
+            path = path.getParent();
+            if (path == null) {
+                break;
+            }
+        }
+    }
+
     /**
      * Apply the changes of a node to the cache.
      *
@@ -815,18 +827,6 @@ public class Commit {
             w.tag('^').key(p.getName()).object().endObject();
         }
         cacheEntry.append(path, w.toString());
-    }
-
-    private void markChanged(Path path) {
-        while (true) {
-            if (!modifiedNodes.add(path)) {
-                break;
-            }
-            path = path.getParent();
-            if (path == null) {
-                break;
-            }
-        }
     }
 
     private boolean isBundled(Path path) {

--- a/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/SimpleTest.java
+++ b/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/SimpleTest.java
@@ -105,7 +105,7 @@ public class SimpleTest {
         String rev4 = mk.commit("/test", "^\"a/x\":1", null, null);
 
         String r0 = mk.getNodes("/", rev0, 0, 0, Integer.MAX_VALUE, ":id");
-        assertEquals("{\":id\":\"/@r0-0-1\",\":childNodeCount\":0}", r0);
+        assertEquals("{\":id\":\"/@r1-0-1\",\":childNodeCount\":0}", r0);
         String r1 = mk.getNodes("/", rev1, 0, 0, Integer.MAX_VALUE, ":id");
         assertEquals("{\":id\":\"/@r2-0-1\",\"test\":{},\":childNodeCount\":1}", r1);
         String r2 = mk.getNodes("/", rev2, 0, 0, Integer.MAX_VALUE, ":id");


### PR DESCRIPTION
- Simplified the test a bit
- Avoided read of root document by reading the _lastRev via the root state's getLastRevision()
- Putting the new head revision into unsavedLastRevisions is already done in DocumentNodeStore.done() within the headOfQueue() method -> c.applyLastRevUpdates(). However, this only works when the root path is considered modified. Made Commit.markChanged() package private for this purpose and used it in maybeRefreshHeadRevision().